### PR TITLE
[36기 문보성]캐러셀 레이아웃 및 Footer 수정 및 통신완료

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -9,7 +9,6 @@ import Resume from './pages/Resume/Resume';
 import ResumeForm from './pages/Resume/ResumeForm/ResumeForm';
 import DetailMain from './pages/DetailMain/DetailMain';
 import KakaoRedirectHandler from './components/Login/KakaoRedirectHandler';
-import CareerNav from './pages/Career/components/CareerNav/CareerNav';
 
 const Router = () => {
   return (
@@ -25,11 +24,10 @@ const Router = () => {
 
         <Route path="/mypage" element={<MyPage />} />
         <Route path="/detail" element={<DetailMain />} />
-        <Route path="/recruitList" element={<RecruitList />} />
+        <Route path="/recruitlist" element={<RecruitList />} />
         <Route path="/resume" element={<Resume />} />
         <Route path="/resume/form" element={<ResumeForm />} />
         <Route path="/resume/:resumesId" element={<ResumeForm />} />
-        <Route path="/career" element={<CareerNav />} />
       </Routes>
       <Footer />
     </BrowserRouter>

--- a/src/api.js
+++ b/src/api.js
@@ -1,14 +1,17 @@
 const BASE_URL = 'http://10.58.4.73:3000';
+const BASE_URL2 = 'http://10.58.5.62:3000';
+const BASE_URL4 = 'http://10.58.0.52:3000';
 const AWS_URL = process.env.REACT_APP_AWS_IP;
 
 export const API = {
   UPLOAD_RESUME: `${BASE_URL}/resume/upload`,
   GET_RESUMES: `${BASE_URL}/resumes/list`,
   GET_RESUME_DETAIL: `${BASE_URL}/resumes`,
-  POST_LOGIN: `${BASE_URL}/auths/kakao-login`,
   GET_JOBS: `${AWS_URL}/jobs/list`,
+  GET_JOBTAGS: `${BASE_URL4}/jobs/main?jobTags=2`,
   POST_ADD_RESUME: `${BASE_URL}/resumes/addresume`,
   POST_ADD_SKILL: `${BASE_URL}/resumes/addskill`,
   POST_ADD_CAREERS: `${BASE_URL}/resumes/addusercareer`,
   POST_ADD_LINK: `${BASE_URL}/resumes/addurl`,
+  POST_LOGIN: `${BASE_URL2}/auths/kakao-login`,
 };

--- a/src/components/Footer/Footer.Styled.js
+++ b/src/components/Footer/Footer.Styled.js
@@ -3,7 +3,8 @@ import styled from 'styled-components';
 
 export const footerMenu = styled.div`
   font-weight: ${props => props.font};
-  font-size: 25px;
+  font-size: 20px;
+  padding-right: 50px;
 `;
 
 export const FooterInfo = styled.div`
@@ -15,10 +16,10 @@ export const FooterInfo = styled.div`
 export const MenuWrap = styled.div`
   display: flex;
   align-items: center;
-  justify-content: space-around;
   width: 100%;
   border-top: 1px solid lightgray;
   padding: 30px 0px 30px 0px;
+  padding-left: 5%;
 `;
 
 export const InfoWrap = styled.div`
@@ -26,7 +27,7 @@ export const InfoWrap = styled.div`
   justify-content: space-between;
   width: 90%;
   padding-top: 1%;
-  margin-left: 5%;
+  margin: 0% 0% 5% 5%;
   border-top: 1px solid lightgray;
 `;
 

--- a/src/pages/Main/Main.Styled.js
+++ b/src/pages/Main/Main.Styled.js
@@ -4,6 +4,10 @@ import search from '../../assets/search.png';
 import company from '../../assets/company.png';
 import user from '../../assets/user.png';
 
+export const MapWrap = styled.div`
+  width: 70%;
+`;
+
 export const Search = styled.img.attrs({ src: `${search}` })`
   position: absolute;
   width: 30px;
@@ -14,23 +18,35 @@ export const Wrap = styled.div`
   margin: 5% auto;
   width: 100%;
   .slick-prev {
-    left: calc((100% - 1440px) / 2);
-    z-index: 9999;
+    left: calc((100% - 1550px) / 2);
+    z-index: 9;
+    ::before {
+      ${variables.flex()}
+      position: absolute;
+      top: -95px;
+      width: 40px;
+      height: 90px;
+      opacity: 0.75;
+      border-radius: 30px;
+      background-color: #fff;
+      color: #6666;
+      content: '<';
+    }
   }
   .slick-next {
-    right: calc((100% - 1400px) / 2);
-  }
-  .slick-prev:before,
-  .slick-next:before {
-    ${variables.flex()}
-    position: absolute;
-    top: -95px;
-    width: 40px;
-    height: 90px;
-    opacity: 0.75;
-    border-radius: 30px;
-    background-color: #fff;
-    color: #6666;
+    right: calc((100% - 1500px) / 2);
+    ::before {
+      ${variables.flex()}
+      position: absolute;
+      top: -95px;
+      width: 40px;
+      height: 90px;
+      opacity: 0.75;
+      border-radius: 30px;
+      background-color: #fff;
+      color: #6666;
+      content: '>';
+    }
   }
 `;
 
@@ -38,7 +54,7 @@ export const PositionInfo = styled.div`
   ${variables.flex()}
   ${variables.absoluteCenter}
   height: 80px;
-  width: 90%;
+  width: 70%;
   color: white;
   font-size: 18px;
   font-weight: 700;
@@ -55,11 +71,12 @@ export const PositionInfo = styled.div`
   );
 `;
 
-export const CarouselShortCut = styled.a`
+export const CarouselShortCut = styled.div`
   ${variables.flex()}
   padding-top: 20px;
   font-weight: bold;
   text-decoration: none;
+  color: blue;
 `;
 
 export const CompanySubInfo = styled.div`
@@ -76,9 +93,10 @@ export const CompanyInfo = styled.div`
 `;
 
 export const Company = styled.img`
+  ${variables.flex()}
   width: 100%;
-  height: 400px;
-  padding: 12px 12px 25px 12px;
+  height: 500px;
+  padding: 12px 15px 25px 15px;
 `;
 
 export const JobSuggest = styled.div`
@@ -159,8 +177,8 @@ export const WorkOrLeaveButton = styled.button`
 export const ProfileMatchUp = styled.ul`
   ${variables.flex()};
   height: 100px;
-  width: 100%;
-  padding: 60px 121px 85px 121px;
+  width: 70%;
+  margin-left: 15%;
 `;
 
 export const Profile = styled.li`
@@ -222,6 +240,7 @@ export const TagDetail = styled.div`
 `;
 
 export const JobInfoImg = styled.img`
+  ${variables.flex()}
   width: 100%;
   height: 400px;
   padding: 12px 12px 12px 12px;
@@ -266,26 +285,45 @@ export const companyDepartButton = styled.div`
 export const JobInfoWrap = styled.div`
   margin: 5% auto;
   width: 100%;
-  padding: 0px 50px 0px 50px;
+  padding: 0px 15% 0px 15%;
 
   .slick-prev {
     left: calc((100% - 1330px) / 2);
     z-index: 9999;
+    ::before {
+      ${variables.flex()}
+      position: absolute;
+      top: -280px;
+      width: 50px;
+      height: 50px;
+      opacity: 0.75;
+      border-radius: 50%;
+      background-color: white;
+      border: 1px solid lightgray;
+      color: #e1e2e3;
+      box-shadow: 0 2px 2px 0 rgb(0 0 0 / 10%);
+      pointer-events: all;
+      content: '<';
+    }
   }
   .slick-next {
     right: calc((100% - 1260px) / 2);
-  }
-  .slick-prev:before,
-  .slick-next:before {
-    ${variables.flex()}
-    position: absolute;
-    top: -280px;
-    width: 50px;
-    height: 50px;
-    opacity: 1;
-    border-radius: 50%;
-    background-color: white;
-    border: 1px solid #e1e2e3;
-    color: #e1e2e3;
+    &:hover {
+      color: solid black;
+    }
+    ::before {
+      ${variables.flex()}
+      position: absolute;
+      top: -280px;
+      width: 50px;
+      height: 50px;
+      opacity: 0.75;
+      border-radius: 50%;
+      background-color: white;
+      border: 1px solid lightgray;
+      color: #e1e2e3;
+      box-shadow: 0 2px 2px 0 rgb(0 0 0 / 10%);
+      content: '>';
+    }
   }
 `;

--- a/src/pages/Main/Main.js
+++ b/src/pages/Main/Main.js
@@ -3,8 +3,12 @@ import Slider from 'react-slick';
 import * as S from './Main.Styled.js';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
+import { goToUrl } from '../../utills.js';
+import { useNavigate } from 'react-router-dom';
+import { API } from '../../api';
 
 export default function Main() {
+  const navigate = useNavigate();
   const [carouselData, setCarouselData] = useState([]);
   const [jobInfoData, setJobInfoData] = useState([]);
 
@@ -17,12 +21,14 @@ export default function Main() {
   }, []);
 
   useEffect(() => {
-    fetch('/data/JobInfoData.json', {
+    fetch(`${API.GET_JOBTAGS}`, {
       method: 'GET',
     })
       .then(response => response.json())
       .then(data => setJobInfoData(data));
   }, []);
+
+  const { jobs } = jobInfoData;
 
   const settings = {
     infinite: true,
@@ -31,6 +37,7 @@ export default function Main() {
     slidesToShow: 1,
     slidesToScroll: 1,
     centerMode: true,
+    centerPadding: '300px',
     pauseOnHover: true,
     autoplaySpeed: 3000,
   };
@@ -47,21 +54,19 @@ export default function Main() {
         <Slider {...settings}>
           {carouselData?.map(carouselList => {
             return (
-              <>
+              <S.MapWrap key={carouselList.id}>
                 <S.Company src={carouselList.img} />
                 <S.CompanyInfo>{carouselList.companyInfo}</S.CompanyInfo>
                 <S.CompanySubInfo>
                   {carouselList.companySubInfo}
                 </S.CompanySubInfo>
-                <S.CarouselShortCut href="www.wecode.com">
-                  바로가기 〉
-                </S.CarouselShortCut>
-              </>
+                <S.CarouselShortCut>바로가기 〉</S.CarouselShortCut>
+              </S.MapWrap>
             );
           })}
         </Slider>
       </S.Wrap>
-      <S.PositionInfo>
+      <S.PositionInfo onClick={() => goToUrl(navigate, '/recruitlist')}>
         채용 중인 포지션 보러가기
         <S.Search />
       </S.PositionInfo>
@@ -93,27 +98,26 @@ export default function Main() {
       </S.ProfileMatchUp>
       <S.JobInfoWrap>
         <S.Tag>
-          <S.TagBold>
-            #{jobInfoData.length > 0 && jobInfoData[0].tag}{' '}
-          </S.TagBold>
+          <S.TagBold>{jobInfoData.length > 0 && jobInfoData[0].tag} </S.TagBold>
           회사를 소개합니다
         </S.Tag>
-        <S.TagDetail>바로가기 〉</S.TagDetail>
+        <S.TagDetail>포지션으로 더보기 〉</S.TagDetail>
         <Slider {...JobInfoCarousel}>
-          {jobInfoData.map(jobInfoList => {
-            return (
-              <>
-                <S.JobInfoImg src={jobInfoList.mainImageUrl} />
-                <S.companyDepartButton>
-                  <S.CompanyAndDepart key={jobInfoList.jobId}>
-                    <S.CompanyName>{jobInfoList.companyName}</S.CompanyName>
-                    <S.Department>{jobInfoList.department}</S.Department>
-                  </S.CompanyAndDepart>
-                  <S.JobInfoButton>팔로우</S.JobInfoButton>
-                </S.companyDepartButton>
-              </>
-            );
-          })}
+          {jobs &&
+            jobs.map(jobInfoList => {
+              return (
+                <S.MapWrap key={jobInfoList.jobId}>
+                  <S.JobInfoImg src={jobInfoList.mainImageUrl} />
+                  <S.companyDepartButton key={jobInfoList.jobId}>
+                    <S.CompanyAndDepart>
+                      <S.CompanyName>{jobInfoList.companyName}</S.CompanyName>
+                      <S.Department>{jobInfoList.department}</S.Department>
+                    </S.CompanyAndDepart>
+                    <S.JobInfoButton>팔로우</S.JobInfoButton>
+                  </S.companyDepartButton>
+                </S.MapWrap>
+              );
+            })}
         </Slider>
       </S.JobInfoWrap>
     </>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 리뷰 반영
- [X] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 캐러셀 레이아웃 및 Footer 수정
- 메인 캐러셀 사진 레이아웃 수정
- Arrow icon 수정
- Footer 레이아웃 수정

## :: 하단 carousel 통신 완료
- 하단 carousel 통신완료

<br />

## :: 메인 캐러셀 양측 사진 조금 더 안쪽으로 보이게 + Arrow 아이콘 수정

## :: Footer 패딩 및 마진 수정 

## :: 백엔드와 carousel 통신 완료
<br />

## :: 성장 포인트
- 캐러셀의 전체적인 사진 레이아웃을 캐러셀 옵션에서 `centerPadding: '300px',` 으로 바꾼다는것을 알게되었습니다.
- 캐러셀의 화살표 아이콘을 Content에 담아 간편히 바꿀수 있다는 것을 알게 되었습니다.
- 이름이 달린 백데이터를 가지고 와서 구조분해 할당을 하고 map을 사용해볼 기회가 1차에는 없었지만 이번에 사용할수 있었습니다.
